### PR TITLE
Fix policy name typo - private CA was used instead of public CA

### DIFF
--- a/service-mesh/istio/common/cert-policy-and-rbac.yaml
+++ b/service-mesh/istio/common/cert-policy-and-rbac.yaml
@@ -16,7 +16,7 @@ spec:
     venafi:
       values:
         venafiConnectionName: vtpp-connection
-        zone: ${JS_VENAFI_TPP_ZONE_PRIVATE_CA1}
+        zone: ${JS_VENAFI_TPP_ZONE_PUBLIC_CA1}
   selector:
     issuerRef:
       name: "v*-public-issuer"


### PR DESCRIPTION
Fix policy name typo that was incorrectly using a private CA instead of public CA