### PR TITLE
changes made to rename issuer and connection to have only one referen…

### DIFF
--- a/certificate-approver/templates/cert-policy.yaml
+++ b/certificate-approver/templates/cert-policy.yaml
@@ -15,10 +15,10 @@ spec:
   plugins:
     venafi:
       values:
-        venafiConnectionName: vtpp-connection
-        zone: ${JS_VENAFI_TPP_ZONE_PUBLIC_CA1}
+        venafiConnectionName: venafi-connection
+        zone: ${JS_VENAFI_ZONE_PUBLIC_CA1}
   selector:
     issuerRef:
-      name: "vtpp-cluster-issuer"
+      name: "venafi-cluster-issuer"
       kind: "VenafiClusterIssuer"
       group: "jetstack.io"

--- a/certificate-approver/templates/sample-cert1.yaml
+++ b/certificate-approver/templates/sample-cert1.yaml
@@ -14,7 +14,7 @@ spec:
     - sample-cert1.${JS_JETSTACKER_DOMAIN_NAME}
   commonName: sample-cert1.${JS_JETSTACKER_DOMAIN_NAME}
   issuerRef:
-    name: "vtpp-cluster-issuer"
+    name: "venafi-cluster-issuer"
     kind: "VenafiClusterIssuer"
     group: "jetstack.io"
 --- 

--- a/certificate-approver/templates/sample-cert2.yaml
+++ b/certificate-approver/templates/sample-cert2.yaml
@@ -14,7 +14,7 @@ spec:
     - sample-cert2.${JS_JETSTACKER_DOMAIN_NAME}
   commonName: sample-cert2.${JS_JETSTACKER_DOMAIN_NAME}
   issuerRef:
-    name: "vtpp-cluster-issuer"
+    name: "venafi-cluster-issuer"
     kind: "VenafiClusterIssuer"
     group: "jetstack.io"
 --- 

--- a/certificate-approver/templates/sample-cert3.yaml
+++ b/certificate-approver/templates/sample-cert3.yaml
@@ -14,7 +14,7 @@ spec:
     - sample-cert3.${JS_JETSTACKER_DOMAIN_NAME}.foo
   commonName: sample-cert3.${JS_JETSTACKER_DOMAIN_NAME}.foo
   issuerRef:
-    name: "vtpp-cluster-issuer"
+    name: "venafi-cluster-issuer"
     kind: "VenafiClusterIssuer"
     group: "jetstack.io"
 --- 

--- a/certificate-approver/templates/venafi-issuer.yaml
+++ b/certificate-approver/templates/venafi-issuer.yaml
@@ -4,8 +4,8 @@
 apiVersion: jetstack.io/v1alpha1
 kind: VenafiClusterIssuer
 metadata:
-  name: vtpp-cluster-issuer
+  name: venafi-cluster-issuer
 spec:
-  venafiConnectionName: vtpp-connection
-  zone: ${JS_VENAFI_TPP_ZONE_PUBLIC_CA1}
+  venafiConnectionName: venafi-connection
+  zone: ${JS_VENAFI_ZONE_PUBLIC_CA1}
 ---

--- a/common/templates/venafi-cloud-connection.yaml
+++ b/common/templates/venafi-cloud-connection.yaml
@@ -1,7 +1,7 @@
 apiVersion: jetstack.io/v1alpha1
 kind: VenafiConnection
 metadata:
-  name: venafi-cloud-connection
+  name: venafi-connection
   namespace: jetstack-secure
 spec:
   vaas:

--- a/common/templates/venafi-tpp-connection.yaml
+++ b/common/templates/venafi-tpp-connection.yaml
@@ -1,7 +1,7 @@
 apiVersion: jetstack.io/v1alpha1
 kind: VenafiConnection
 metadata:
-  name: vtpp-connection
+  name: venafi-connection
   namespace: jetstack-secure
 spec:
   tpp:

--- a/docs/02.create-venafi-connection.md
+++ b/docs/02.create-venafi-connection.md
@@ -55,7 +55,7 @@ make create-venafi-tpp-connection
 ```
 and you should see
 ```
-venaficonnection.jetstack.io/vtpp-connection created
+venaficonnection.jetstack.io/venafi-connection created
 ```
 
 To create a `VenafiConnection` resource for TLS Protect - Cloud run the following.
@@ -64,7 +64,7 @@ make create-venafi-cloud-connection
 ```
 and you should see
 ```
-venaficonnection.jetstack.io/venafi-cloud-connection created
+venaficonnection.jetstack.io/venafi-connection configured
 ```
 
 To validate that the `VenafiConnection` resources have been created, run
@@ -75,9 +75,8 @@ kubectl get VenafiConnection -n jetstack-secure
 and you will see
 ```
 ❯ kubectl get VenafiConnection -n jetstack-secure
-NAME                      AGE
-venafi-cloud-connection   11s
-vtpp-connection           40s
+NAME                AGE
+venafi-connection   63s
 ```
 
 These connections will be used to create the `VenafiIssuer` or `VenafiClusterIssuer` resources as required to fulfill `CertificateRequests`

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -7,7 +7,7 @@ SHELL := bash
 SHELL := /bin/sh
 
 # Include personal settings
- include ../settings.sh
+include ../settings.sh
 
 ## GCP Targets 
 create-gke-cluster:

--- a/settings-template.sh
+++ b/settings-template.sh
@@ -1,51 +1,46 @@
-export JS_ENTERPRISE_CREDENTIALS_FILE := /Users/riaz.mohamed/sandbox/gitprojects/clean/jetstackdemosv2/demos/js-enterprise-credentials-1.json
+export JS_ENTERPRISE_CREDENTIALS_FILE := /path/to/js-enterprise-credentials.json
 
 
 ###########################
 # Venafi Specific Variables
 ###########################
 
-# Venafi TPP access token. You must have the Venafi platform up and running
+# Venafi TLSPC-DC access token. You must have the Venafi platform up and running
 export JS_VENAFI_TPP_ACCESS_TOKEN :=REPLACE-ME
 export JS_VENAFI_TPP_REFRESH_TOKEN :=REPLACE-ME
 export JS_VENAFI_TPP_REFRESH_TOKEN_EXPIRY :=REPLACE-ME
-
-export JS_VENAFI_CLIENTID := cert-manager.io
-export JS_CONTAINER_REGISTRY := eu.gcr.io/jetstack-secure-enterprise
-
+export JS_VENAFI_TPP_USERNAME := REPLACE-ME # E.g. user1
+export JS_VENAFI_TPP_PASSWORD := REPLACE-ME # E.g. userpass
 export JS_VENAFI_TPP_URL :=REPLACE-ME # E.g. https://tpp.mydomain.com/vedsdk
-
 #Reference to file that contains CA bundle in PEM format. This is the certchain to tpp.mydomain.com. venafi-tpp-server-ca.pem is in .gitignore 
 export JS_VENAFI_TPP_CA_BUNDLE_PEM_FILE :=~/GitHub/demos/venafi-tpp-server-ca.pem
+export JS_VENAFI_CLIENTID := cert-manager.io
 #Base64 encoding of the above
-export JS_VENAFI_TPP_BASE64_ENCODED_CACERT :=REPLACE-ME
-export JS_VENAFI_TPP_ZONE_PUBLIC_CA1 := REPLACE-ME # E.g. Certificates\\\\Kubernetes\\\\Public1
-export JS_VENAFI_TPP_ZONE_PUBLIC_CA2 := REPLACE-ME # E.g. Certificates\\\\Kubernetes\\\\Public2
-
-#Reference to file that contains CA bundle in PEM format for Private PKI. This is the root CA for PKI referenced in PRIVATE_CA$. 
-#venafi-msca-ica-root.pem is in .gitignore 
-export JS_VENAFI_INTERMEDIATE_CA_ROOT_PEM_FILE :=~/GitHub/demos/venafi-msca-ica-root.pem
-export JS_VENAFI_TPP_ZONE_PRIVATE_CA1 := REPLACE-ME # E.g. Certificates\\Kubernetes\\Private1
-export JS_VENAFI_TPP_ZONE_PRIVATE_CA2 := REPLACE-ME # E.g. Certificates\\Kubernetes\\Private2
-
-#Location to sync certificates between Kubernetes and Venafi TPP
-export JS_VENAFI_CERT_SYNC_POLICY_FOLDER := REPLACE-ME # E.g. Certificates\\\\Kubernetes\\\\Discovered
+#export JS_VENAFI_TPP_BASE64_ENCODED_CACERT :=REPLACE-ME
 
 # Venafi API Key. Register for an account on ui.venafi.cloud for a key.
 export JS_VENAFI_CLOUD_API_KEY :=REPLACE-ME
 
-# Figure out escaping on your own !!. Using \\ here. Had to use \\\\ For Venafi TPP.
-export JS_VENAFI_CLOUD_PUBLIC_ZONE_ID1 :=Demo\\demo
-export JS_VENAFI_CLOUD_PUBLIC_ZONE_ID2 :=Demo\\demo
+#Firefly config
+export JS_VENAFI_FIREFLY_CLIENT_ID :=:=b45axxx0-xxxx-xxxx-xxxx-f78e8339xxxx
 
-# Venafi Zone ID for CSI driver specific usecases.
-# Due to escaping \\ becomes one \, so Demo\\\\demo becomes Demo\\demo
-export JS_VENAFI_CLOUD_PRIVATE_ZONE_ID1 :=Demo\\\\demo
-export JS_VENAFI_CLOUD_PRIVATE_ZONE_ID2 :=Demo\\\\demo
+export JS_VENAFI_ZONE_PUBLIC_CA1 := REPLACE-ME # E.g. Certificates\\\\Kubernetes\\\\Public1
+export JS_VENAFI_ZONE_PUBLIC_CA2 := REPLACE-ME # E.g. Certificates\\\\Kubernetes\\\\Public2
 
-export JS_VENAFI_TPP_USERNAME := REPLACE-ME # E.g. user1
-export JS_VENAFI_TPP_PASSWORD := REPLACE-ME # E.g. userpass
+#Reference to file that contains CA bundle in PEM format for Private PKI. This is the root CA for PKI referenced in PRIVATE_CA$. 
 
+export JS_VENAFI_ZONE_PRIVATE_CA1 := REPLACE-ME # E.g. Certificates\\Kubernetes\\Private1
+export JS_VENAFI_ZONE_PRIVATE_CA2 := REPLACE-ME # E.g. Certificates\\Kubernetes\\Private2
+
+#Location to sync certificates between Kubernetes and Venafi TPP
+export JS_VENAFI_CERT_SYNC_POLICY_FOLDER := REPLACE-ME # E.g. Certificates\\\\Kubernetes\\\\Discovered
+
+#venafi-msca-ica-root.pem is in .gitignore 
+export JS_VENAFI_INTERMEDIATE_CA_ROOT_PEM_FILE :=~/GitHub/demos/venafi-msca-ica-root.pem
+
+
+# VENAFI ENTERPRISE REGISTRY CONFIG
+export JS_CONTAINER_REGISTRY := eu.gcr.io/jetstack-secure-enterprise
 # Email for creating docker registry secret that holds Jetstack Secure enterprise access token
 export JS_AIRGAPPED := false
 export JS_DOCKER_REGISTRY_SECRET := venafi-jetstack-enterprise-key
@@ -178,5 +173,4 @@ export JS_SAMPLE_TRUSTSTORE_APP_IMAGE := riazvm/jetstackdemos-truststore:1.3
 
 export JS_OPENSHIFT_ROUTE_IMAGE := ghcr.io/cert-manager/cert-manager-openshift-routes:0.1.3
 
-#Firefly config
-export JS_VENAFI_FIREFLY_CLIENT_ID :=:=b45axxx0-xxxx-xxxx-xxxx-f78e8339xxxx
+


### PR DESCRIPTION
changes made to rename issuer and connection to have only one reference , This will work with both cloud and with tpp instead of having too many files. The changes are made to the following
Documentation update 
Have only one Venafi connection called venafi-connection instead of having vtpp-venafi-connection and venafi-cloud-connection
Only one issue called venafi-issuer

Will be making changes to other use cases , this is the initial check-in for policy approver

